### PR TITLE
Customize openai base url and model

### DIFF
--- a/src/zev/llm.py
+++ b/src/zev/llm.py
@@ -47,7 +47,7 @@ def get_client():
 def get_options(prompt) -> OptionsResponse:
     client = get_client()
     response = client.beta.chat.completions.parse(
-        model="gpt-4o-mini",
+        model=os.getenv("OPENAI_MODEL", default="gpt-4o-mini"),
         messages=[{"role": "user", "content": PROMPT.format(prompt=prompt)}],
         response_format=OptionsResponse,
     )

--- a/src/zev/llm.py
+++ b/src/zev/llm.py
@@ -41,7 +41,7 @@ Here is the users prompt:
 
 
 def get_client():
-    return openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    return openai.OpenAI(base_url=os.getenv("OPENAI_BASE_URL", default=None), api_key=os.getenv("OPENAI_API_KEY"))
 
 
 def get_options(prompt) -> OptionsResponse:


### PR DESCRIPTION
ollama has openai compatibility : https://ollama.com/blog/openai-compatibility

This changes allows to use ollama deployed in local environment like this:
```
$ export OPENAI_BASE_URL=http://localhost:11434/v1
$ export OPENAI_API_KEY=ollama
$ export OPENAI_MODEL=llama3.2
$ zev
Describe what you want to do: configure permissions with setfacl to allow read access to user alpha in dir /tmp/test
? Select command: (Use shortcuts or arrow keys)
 » 1) setfacl -Rm u:alpha:r /tmp/test
   2) Cancel
   ---------------
  Description: Set filesystem ACLs for a directory and all its contents, deny write access to the owner, group, others
```
