### PR TITLE
Fix ollama api-key error

### DIFF
--- a/src/zev/llms/ollama/provider.py
+++ b/src/zev/llms/ollama/provider.py
@@ -15,5 +15,5 @@ class OllamaProvider(OpenAIProvider):
             raise ValueError("OLLAMA_BASE_URL must be set. Try running `zev --setup`.")
         if not config.ollama_model:
             raise ValueError("OLLAMA_MODEL must be set. Try running `zev --setup`.")
-        self.client = OpenAI(base_url=config.ollama_base_url)
+        self.client = OpenAI(base_url=config.ollama_base_url, api_key="ollama")
         self.model = config.ollama_model


### PR DESCRIPTION
While trying to use ollama as the backend, i got the below error.
```
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

I then found out that you need to pass `api_key="ollama"` to the OpenAI library [(Refer here)](https://github.com/ollama/ollama/blob/5cfc1c39f3d5822b0c0906f863f6df45c141c33b/docs/openai.md?plain=1#L19) . So i made this quick fix.