### PR TITLE
feat: add support for custom OpenAI-compatible API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ zev --setup
 
 To use OpenAI, you need an OpenAI account and a subscription. You can create an API key on [this page](https://platform.openai.com/settings/organization/api-keys).
 
+#### Using OpenAI-Compatible APIs (OpenRouter, etc.)
+
+Zev supports OpenAI-compatible APIs like [OpenRouter](https://openrouter.ai/), which provides access to many models including some with free tiers. During setup, you can specify a custom base URL:
+
+```bash
+? Your OPENAI api key: sk-or-v1-xxxxx  # Your OpenRouter API key
+? Choose which model you would like to default to: gpt-4o-mini
+? Custom API base URL: https://openrouter.ai/api/v1
+```
+
+Leave the custom base URL empty to use the default OpenAI API.
+
 ### Google Gemini (Free)
 
 To use Google's Gemini models, you need a Google AI Studio account. You can create a Gemini API key in [Google AI Studio](https://aistudio.google.com/).

--- a/src/zev/config/__init__.py
+++ b/src/zev/config/__init__.py
@@ -21,6 +21,10 @@ class Config:
     def openai_model(self):
         return self.vals.get("OPENAI_MODEL")
 
+    @property
+    def openai_base_url(self):
+        return self.vals.get("OPENAI_BASE_URL")
+
     # Ollama
     @property
     def ollama_base_url(self):

--- a/src/zev/llms/openai/provider.py
+++ b/src/zev/llms/openai/provider.py
@@ -15,7 +15,9 @@ class OpenAIProvider(InferenceProvider):
         if not config.openai_api_key:
             raise ValueError("OPENAI_API_KEY must be set. Try running `zev --setup`.")
 
-        self.client = OpenAI(base_url=OPENAI_BASE_URL, api_key=config.openai_api_key)
+        # Use custom base URL if provided, otherwise use the default OpenAI URL
+        base_url = config.openai_base_url or OPENAI_BASE_URL
+        self.client = OpenAI(base_url=base_url, api_key=config.openai_api_key)
         self.model = config.openai_model or OPENAI_DEFAULT_MODEL
 
     def get_options(self, prompt: str, context: str) -> OptionsResponse | None:

--- a/src/zev/llms/openai/setup.py
+++ b/src/zev/llms/openai/setup.py
@@ -26,4 +26,9 @@ questions = (
             ),
         ],
     ),
+    SetupQuestionText(
+        name="OPENAI_BASE_URL",
+        prompt="Custom API base URL (leave empty for default OpenAI API, or enter URL for OpenRouter/other compatible APIs):",
+        default="",
+    ),
 )


### PR DESCRIPTION
## Summary
This PR adds support for custom OpenAI-compatible API URLs, allowing users to use services like OpenRouter, local LLM servers, or other OpenAI-compatible endpoints.

## Changes
- Add `OPENAI_BASE_URL` config option in the config module
- Update OpenAI provider to use custom base URL when provided (falls back to default OpenAI API)
- Add setup question for custom API base URL during `zev --setup`
- Update README with documentation for using OpenAI-compatible APIs

## Usage
Users can now configure a custom base URL during setup:

```bash
? Your OPENAI api key: sk-or-v1-xxxxx
? Choose which model you would like to default to: gpt-4o-mini
? Custom API base URL: https://openrouter.ai/api/v1
```

Leaving the custom base URL empty will use the default OpenAI API.

Closes #35